### PR TITLE
add meta tags in components/page.js

### DIFF
--- a/components/Page.js
+++ b/components/Page.js
@@ -15,6 +15,9 @@ export default withRouter(props => {
 		<>
 			<Head>
 				<title>{props.title ? `${title} • ${props.title}` : title}</title>
+				<meta name="apple-mobile-web-app-title" content="Alles" />
+				<meta name="apple-mobile-web-app-capable" content="yes">
+				<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 				<ThemeScript />
 			</Head>
 


### PR DESCRIPTION
Added the 'apple-mobile-web-app' meta tags.
this should fix fullscreen mode on iOS.
